### PR TITLE
fix: fixes build issue when combined with lower iOS target dependencies

### DIFF
--- a/.github/workflows/post-release-merge.yml
+++ b/.github/workflows/post-release-merge.yml
@@ -1,11 +1,10 @@
 name: Post PR Merge
 
-on: workflow_dispatch
-  # pull_request:
-  #   # Patterns matched against refs/heads
-  #   branches:
-  #     - release/next
-  #   types: [ closed ]
+on: 
+  pull_request:
+    branches:
+      - release/next
+    types: [ closed ]
 
 jobs:
   release_merge:

--- a/PrimerNolPaySDK.podspec
+++ b/PrimerNolPaySDK.podspec
@@ -19,10 +19,14 @@ A wrapper around the Nol payment SDK.
   s.author           = { 'Primer' => 'dx@primer.io' }
   s.source           = { :git => 'https://github.com/primer-io/primer-nol-pay-sdk-ios.git', :tag => s.version.to_s }
 
+  s.swift_version = '5'
   s.ios.deployment_target = '13.1'
 
   s.ios.source_files = 'Sources/PrimerNolPaySDK/Classes/*.{swift}'
   s.ios.frameworks  = 'Foundation', 'UIKit'
   s.ios.vendored_frameworks = 'Sources/Frameworks/TransitSDK.xcframework'
+
+  s.ios.pod_target_xcconfig = { "BUILD_LIBRARY_FOR_DISTRIBUTION" => 'YES' }
+  s.xcconfig = { 'OTHER_SWIFT_FLAGS' => '-no-verify-emitted-module-interface' }
 
 end


### PR DESCRIPTION
This PR adds the flags in the Podspec which we see in `Primer3DS`, which allow us to mix the `iOS 13.1` target of `PrimerNolPaySDK` with the original `iOS 10` target of `PrimerSDK`

This PR also implements the automatic tagging workflow for trial.

This requires a companion PR in `primer-sdk-ios` - which will require this to be released to prepare